### PR TITLE
Personal messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,15 @@ curl \
   -H "Subject: Test smtp_to_telegram" -F '=(;type=multipart/mixed' -F "=This message came via smtp;type=text/plain" -F '=)'
 ```
 
+Sending personal messages is supported. Instead of email, enter an entry like `000000000@telegram.org`. Where `000000000` is `chat id`.
+Classic emails will still be sent to the `ID` specified in `ST_TELEGRAM_CHAT_IDS`.
+
 ## Options
 
 A custom format might be specified as well:
 ```
 ST_TELEGRAM_BOT_TOKEN=<BOT_TOKEN>
-ST_TELEGRAM_CHAT_IDS=<CHAT_ID1>,<CHAT_ID2>
+ST_TELEGRAM_CHAT_IDS=<CHAT_ID1>,<CHAT_ID2> # optional
 ST_TELEGRAM_MESSAGE_TEMPLATE="Subject: {subject}\\n\\n{body}" # optional
 ST_SMTP_ALLOWED_HOSTS=cvzilla.net,example.com # optional
 ```

--- a/README.md
+++ b/README.md
@@ -35,17 +35,28 @@ docker compose up
 You may use `localhost:25` as the target SMTP address.
 No TLS or authentication is required.
 
-The default Telegram message format is:
+## How to use
 
+Request to check the service:
 ```
-From: {from}\\nTo: {to}\\nSubject: {subject}\\n\\n{body}\\n\\n{attachments_details}
+curl \
+  --url 'smtp://localhost:25' \
+  --mail-from sender@test.test \
+  --mail-rcpt user@test.test --mail-rcpt user1@test.test \
+  -H "Subject: Test smtp_to_telegram" -F '=(;type=multipart/mixed' -F "=This message came via smtp;type=text/plain" -F '=)'
 ```
+
+## Options
 
 A custom format might be specified as well:
-
 ```
-ST_TELEGRAM_CHAT_IDS=<CHAT_ID1>,<CHAT_ID2>
 ST_TELEGRAM_BOT_TOKEN=<BOT_TOKEN>
-ST_TELEGRAM_MESSAGE_TEMPLATE="Subject: {subject}\\n\\n{body}"
-ST_SMTP_ALLOWED_HOSTS=cvzilla.net,example.com
+ST_TELEGRAM_CHAT_IDS=<CHAT_ID1>,<CHAT_ID2>
+ST_TELEGRAM_MESSAGE_TEMPLATE="Subject: {subject}\\n\\n{body}" # optional
+ST_SMTP_ALLOWED_HOSTS=cvzilla.net,example.com # optional
+```
+
+The default Telegram message format is:
+```
+From: {from}\\nTo: {to}\\nSubject: {subject}\\n\\n{body}\\n\\n{attachments_details}
 ```


### PR DESCRIPTION
I have implemented a mechanism for sending personal messages. This is very similar to what was described in #1.

Sending personal messages is implemented using a special mail address, like `000000000@telegram.org`. You can find more details in `README.md`.

Why is this option better than `map email to chatid`:
- The service user can independently set and change his `chat id` (For example in LDAP)
- Server configuration becomes easier
